### PR TITLE
Increase controls bar height

### DIFF
--- a/QImageSelect.py
+++ b/QImageSelect.py
@@ -141,7 +141,7 @@ class QImageSelect(QDialog):
         ).transformed(self.transform, Qt.TransformationMode.SmoothTransformation)
         width = pixmap.width()
         hight = pixmap.height()
-        self.setFixedSize(width, hight + 45)
+        self.setFixedSize(width, hight + 64)
         self.view.setPixmap(pixmap)
 
     class QImageLabel(QLabel):


### PR DESCRIPTION
For me, the actual height of the controls bar is higher than the value you use, whether because of Qt UI updates or Windows updates&mdash;I am on Windows 11. The right way to solve this problem is to calculate the height, but I am 80% sure 64px is the actual height of the controls on my machine: any lower cuts off the bottom of the image.